### PR TITLE
Fix HCL support for ProfitBricks plugin

### DIFF
--- a/builder/profitbricks/config.go
+++ b/builder/profitbricks/config.go
@@ -24,7 +24,6 @@ type Config struct {
 
 	Region       string `mapstructure:"location"`
 	Image        string `mapstructure:"image"`
-	SSHKey       string
 	SnapshotName string `mapstructure:"snapshot_name"`
 	DiskSize     int    `mapstructure:"disk_size"`
 	DiskType     string `mapstructure:"disk_type"`
@@ -37,7 +36,7 @@ type Config struct {
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	var md mapstructure.Metadata
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Metadata:           &md,
 		Interpolate:        true,
 		InterpolateContext: &c.ctx,

--- a/builder/profitbricks/config.hcl2spec.go
+++ b/builder/profitbricks/config.hcl2spec.go
@@ -72,7 +72,6 @@ type FlatConfig struct {
 	PBUrl                     *string           `mapstructure:"url" cty:"url" hcl:"url"`
 	Region                    *string           `mapstructure:"location" cty:"location" hcl:"location"`
 	Image                     *string           `mapstructure:"image" cty:"image" hcl:"image"`
-	SSHKey                    *string           `cty:"ssh_key" hcl:"ssh_key"`
 	SnapshotName              *string           `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	DiskSize                  *int              `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	DiskType                  *string           `mapstructure:"disk_type" cty:"disk_type" hcl:"disk_type"`
@@ -155,7 +154,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"url":                          &hcldec.AttrSpec{Name: "url", Type: cty.String, Required: false},
 		"location":                     &hcldec.AttrSpec{Name: "location", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
-		"ssh_key":                      &hcldec.AttrSpec{Name: "ssh_key", Type: cty.String, Required: false},
 		"snapshot_name":                &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_type":                    &hcldec.AttrSpec{Name: "disk_type", Type: cty.String, Required: false},

--- a/builder/profitbricks/step_create_server.go
+++ b/builder/profitbricks/step_create_server.go
@@ -22,9 +22,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 
 	profitbricks.SetAuth(c.PBUsername, c.PBPassword)
 	profitbricks.SetDepth("5")
-	if c.Comm.SSHPublicKey != nil {
-		c.SSHKey = string(c.Comm.SSHPublicKey)
-	} else {
+	if c.Comm.SSHPublicKey == nil {
 		ui.Error("No ssh private key set; ssh authentication won't be possible. Please specify your private key in the ssh_private_key_file configuration key.")
 		return multistep.ActionHalt
 	}
@@ -63,9 +61,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			},
 		},
 	}
-	if c.SSHKey != "" {
-		server.Entities.Volumes.Items[0].Properties.SshKeys = []string{c.SSHKey}
-	}
+	server.Entities.Volumes.Items[0].Properties.SshKeys = []string{string(c.Comm.SSHPublicKey)}
 
 	if c.Comm.SSHPassword != "" {
 		server.Entities.Volumes.Items[0].Properties.ImagePassword = c.Comm.SSHPassword


### PR DESCRIPTION
* This changes fixes a small issue with the Config so that it honors the
  config.FlatConfigurer interface. It also removes the SSHKey config
  attribute which is not needed. The code prior to this change did not
  work with HCL2 tempaltes.

```
: panic: interface conversion: **profitbricks.Config is not
config.flatConfigurer: missing method FlatMapstructure
```
